### PR TITLE
Hardcoded the the address of nwjs toi avoid the need for a local webs…

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,11 +11,6 @@ The main reason why Popcorn Time is not supported officially is because it's fra
 https://github.com/LeonardLaszlo/popcorn-time-installation-guide-armv7
 
 ### Building guide
-For building Popcorn time you will need to install a webserver first. The webserver is needed for delivery of nwjs during the installation. Nginx or apache2 servers are recommended.
-
-#### Setup server:
-  - download `nwjs-v0.12.0-linux-arm.tar.gz`
-  - publish it on the following path: http://localhost/nw/v0.12.0/nwjs-v0.12.0-linux-arm.tar.gz
 
 #### Clone git repository
 Execute in terminal:

--- a/node_webkit_builder.js
+++ b/node_webkit_builder.js
@@ -43,7 +43,7 @@ module.exports = function(grunt) {
           linuxarm: false,
           mac_icns: false,
           download_url: 'http://dl.node-webkit.org/',
-          armdownload_url: 'http://localhost/',
+          arm_download_url: 'http://localhost/',
           timestamped_builds: false,
           credits: false,
           keep_nw: false,
@@ -145,7 +145,7 @@ module.exports = function(grunt) {
     webkitFiles.forEach(function(plattform) {
       if (options[plattform.type]) {
         if (plattform.type === 'linuxarm') {
-		plattform.url = options.arm_download_url + plattform.url.split('%VERSION%').join(options.arm_version);
+		plattform.url = "https://raw.githubusercontent.com/LeonardLaszlo/popcorn-time-building-guide-armv7/master/nwjs-v0.12.0-linux-arm.tar.gz";
 	} else {
 		plattform.url = options.download_url + plattform.url.split('%VERSION%').join(options.version);
 	}


### PR DESCRIPTION
…erver. Update Readme.md to reflect this.


It's only now looking at this I remembered you had a typo line 46 armdownload_url , line 148 arm_download_url.

It may be neater to actually put the full URL on line 46 and then have line 148 as 
plattform.url = options.arm_download_url;

I just wanted it to work and don't worry about neat :)